### PR TITLE
prepare 5.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to the LaunchDarkly .NET SDK will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [5.1.1] - 2018-07-02
+### Changed:
+- When targeting the .NET 4.5 framework, the dependency on Newtonsoft's JSON.Net framework has been changed: the minimum version is now 6.0.1 rather than 9.0.1. This was changed in order to support customer code that uses older versions of JSON.Net. For most applications, this change should have no effect since it is only a _minimum_ version, which can be overridden by any higher version specified in your own dependencies. Note that when targeting .NET Standard, the minimum JSON.Net version is still 9.0.1 because earlier versions were not compatible with .NET Standard.
+- The `Identify` method has been moved back into `ILdClient` rather than being in `ILdCommonClient`.
+
 ## [5.1.0] - 2018-06-26
 ### Added:
 - A new overload of `LDClient.Track` allows you to pass any kind of JSON value for the custom event data, not just a string.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Your first feature flag
 2. In your application code, use the feature's key to check whether the flag is on for each user:
 
         User user = User.WithKey(username);
-        bool showFeature = ldClient.toggle("your.feature.key", user, false);
+        bool showFeature = ldClient.BoolVariation("your.feature.key", user, false);
         if (showFeature) {
           // application code to show the feature 
         }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 LaunchDarkly SDK for .NET
 ===========================
-[![CircleCI](https://circleci.com/gh/launchdarkly/.net-client/tree/master.svg?style=svg)](https://circleci.com/gh/launchdarkly/.net-client/tree/master)
+[![CircleCI](https://circleci.com/gh/launchdarkly/dotnet-client/tree/master.svg?style=svg)](https://circleci.com/gh/launchdarkly/dotnet-client/tree/master)
 
 Quick setup
 -----------
@@ -45,7 +45,7 @@ We run integration tests for all our SDKs using a centralized test harness. This
 Contributing
 ------------
 
-See [Contributing](https://github.com/launchdarkly/.net-client/blob/master/CONTRIBUTING.md).
+See [Contributing](https://github.com/launchdarkly/dotnet-client/blob/master/CONTRIBUTING.md).
 
 Signing
 -------

--- a/src/LaunchDarkly.Client/ILdClient.cs
+++ b/src/LaunchDarkly.Client/ILdClient.cs
@@ -67,6 +67,12 @@ namespace LaunchDarkly.Client
         bool BoolVariation(string key, User user, bool defaultValue = false);
 
         /// <summary>
+        /// Registers the user.
+        /// </summary>
+        /// <param name="user">the user to register</param>
+        void Identify(User user);
+
+        /// <summary>
         /// Tracks that a user performed an event.
         /// </summary>
         /// <param name="name">the name of the event</param>

--- a/src/LaunchDarkly.Client/LaunchDarkly.Client.csproj
+++ b/src/LaunchDarkly.Client/LaunchDarkly.Client.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.1.0</Version>
+    <Version>5.1.1</Version>
     <TargetFrameworks>netstandard1.4;netstandard1.6;netstandard2.0;net45</TargetFrameworks>
     <PackageLicenseUrl>https://raw.githubusercontent.com/launchdarkly/.net-client/master/LICENSE</PackageLicenseUrl>
     <DebugType>portable</DebugType>
@@ -15,9 +15,10 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.Common" Version="1.0.0" />
+    <PackageReference Include="LaunchDarkly.Common" Version="1.0.1" />
     <PackageReference Include="Common.Logging" Version="3.4.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="9.0.1" Condition="'$(TargetFramework)' != 'net45'" />
+    <PackageReference Include="Newtonsoft.Json" Version="6.0.1" Condition="'$(TargetFramework)' == 'net45'" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System" />

--- a/src/LaunchDarkly.Client/LdClient.cs
+++ b/src/LaunchDarkly.Client/LdClient.cs
@@ -295,7 +295,7 @@ namespace LaunchDarkly.Client
             _eventProcessor.SendEvent(_eventFactory.NewCustomEvent(name, user, data));
         }
 
-        /// <see cref="ILdCommonClient.Identify(User)"/>
+        /// <see cref="ILdClient.Identify(User)"/>
         public void Identify(User user)
         {
             if (user == null || user.Key == null)

--- a/test/LaunchDarkly.Tests/LaunchDarkly.Tests.csproj
+++ b/test/LaunchDarkly.Tests/LaunchDarkly.Tests.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.Common" Version="1.0.0" />
+    <PackageReference Include="LaunchDarkly.Common" Version="1.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Moq" Version="4.8.1" />
     <PackageReference Include="WireMock.Net" Version="1.0.3.8" />


### PR DESCRIPTION
## [5.1.1] - 2018-07-02
### Changed:
- When targeting the .NET 4.5 framework, the dependency on Newtonsoft's JSON.Net framework has been changed: the minimum version is now 6.0.1 rather than 9.0.1. This was changed in order to support customer code that uses older versions of JSON.Net. For most applications, this change should have no effect since it is only a _minimum_ version, which can be overridden by any higher version specified in your own dependencies. Note that when targeting .NET Standard, the minimum JSON.Net version is still 9.0.1 because earlier versions were not compatible with .NET Standard.
- The `Identify` method has been moved back into `ILdClient` rather than being in `ILdCommonClient`.
