### PR TITLE
prepare 5.2.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ All notable changes to the LaunchDarkly .NET SDK will be documented in this file
 - The `LaunchDarkly.Common` package, which is used by `LaunchDarkly.Client`, has been renamed to `LaunchDarkly.Common.StrongName`. Note that you should not have to explicitly install this package; it will be imported automatically.
 
 ### Fixed:
-- The SDK was referencing several system assemblies via `<PackageReference>`, which could cause dependency conflicts. These have been changed to framework `<Reference>`s. A redundant reference to `System.Runtime` was removed.
+- The SDK was referencing several system assemblies via `<PackageReference>`, which could cause dependency conflicts. These have been changed to framework `<Reference>`s. A redundant reference to `System.Runtime` was removed. ([#83](https://github.com/launchdarkly/dotnet-client/issues/83))
 - The client was logging (at debug level) a lengthy exception stacktrace whenever a string comparison operator was applied to a user property that was null. It no longer does this.
 
 ## [5.1.1] - 2018-07-02

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to the LaunchDarkly .NET SDK will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org).
 
+## [5.2.0] - 2018-07-27
+### Added:
+- New configuration property `UseLdd` allows the client to use the "LaunchDarkly Daemon", i.e. getting feature flag data from a store that is updated by an [`ld-relay`](https://docs.launchdarkly.com/docs/the-relay-proxy) instance. However, this will not be usable until the Redis feature store integration is released (soon).
+
+### Changed:
+- If you attempt to evaluate a flag before the client has established a connection, but you are using a feature store that has already been populated, the client will now use the last known values from the store instead of returning default values.
+- The `LaunchDarkly.Common` package, which is used by `LaunchDarkly.Client`, has been renamed to `LaunchDarkly.Common.StrongName`. Note that you should not have to explicitly install this package; it will be imported automatically.
+
+### Fixed:
+- The SDK was referencing several system assemblies via `<PackageReference>`, which could cause dependency conflicts. These have been changed to framework `<Reference>`s. A redundant reference to `System.Runtime` was removed.
+- The client was logging (at debug level) a lengthy exception stacktrace whenever a string comparison operator was applied to a user property that was null. It no longer does this.
+
 ## [5.1.1] - 2018-07-02
 ### Changed:
 - When targeting the .NET 4.5 framework, the dependency on Newtonsoft's JSON.Net framework has been changed: the minimum version is now 6.0.1 rather than 9.0.1. This was changed in order to support customer code that uses older versions of JSON.Net. For most applications, this change should have no effect since it is only a _minimum_ version, which can be overridden by any higher version specified in your own dependencies. Note that when targeting .NET Standard, the minimum JSON.Net version is still 9.0.1 because earlier versions were not compatible with .NET Standard.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,11 @@ LaunchDarkly SDK for .NET
 ===========================
 [![CircleCI](https://circleci.com/gh/launchdarkly/dotnet-client/tree/master.svg?style=svg)](https://circleci.com/gh/launchdarkly/dotnet-client/tree/master)
 
+.NET platform compatibility
+---------------------------
+
+This version of the LaunchDarkly SDK is compatible with .NET Framework version 4.5 and above, or .NET Standard 1.4-2.0.
+
 Quick setup
 -----------
 

--- a/src/LaunchDarkly.Client/Components.cs
+++ b/src/LaunchDarkly.Client/Components.cs
@@ -124,6 +124,11 @@ namespace LaunchDarkly.Client
                 Log.Info("Starting Launchdarkly client in offline mode.");
                 return new NullUpdateProcessor();
             }
+            else if (config.UseLdd)
+            {
+                Log.Info("Starting LaunchDarkly in LDD mode. Skipping direct feature retrieval.");
+                return new NullUpdateProcessor();
+            }
             else
             {
                 FeatureRequestor requestor = new FeatureRequestor(config);

--- a/src/LaunchDarkly.Client/Configuration.cs
+++ b/src/LaunchDarkly.Client/Configuration.cs
@@ -110,6 +110,11 @@ namespace LaunchDarkly.Client
         /// only include the user key, except for one "index" event that provides the full details for the user).
         /// </summary>
         public bool InlineUsersInEvents { get; internal set; }
+        /// <summary>
+        /// True if this client should use the <a href="https://docs.launchdarkly.com/docs/the-relay-proxy">LaunchDarkly
+        /// relay</a> in daemon mode, instead of subscribing to the streaming or polling API.
+        /// </summary>
+        public bool UseLdd { get; internal set; }
         // (Used internally, was never public, will remove when WithFeatureStore is removed)
         internal IFeatureStore FeatureStore { get; set; }
         /// <summary>
@@ -437,6 +442,21 @@ namespace LaunchDarkly.Client
         public static Configuration WithReconnectTime(this Configuration configuration, TimeSpan timeSpan)
         {
             configuration.ReconnectTime = timeSpan;
+            return configuration;
+        }
+
+        /// <summary>
+        /// Sets whether this client should use the <a href="https://docs.launchdarkly.com/docs/the-relay-proxy">LaunchDarkly
+        /// relay</a> in daemon mode, instead of subscribing to the streaming or polling API.
+        /// For this to work, you should also be using the
+        /// <a href="https://github.com/launchdarkly/dotnet-client-redis">LaunchDarkly Redis integration</a>.
+        /// </summary>
+        /// <param name="configuration">the configuration</param>
+        /// <param name="useLdd">true to use the relay in daemon mode; false to use streaming or polling</param>
+        /// <returns>the same <c>Configuration</c> instance</returns>
+        public static Configuration WithUseLdd(this Configuration configuration, bool useLdd)
+        {
+            configuration.UseLdd = useLdd;
             return configuration;
         }
 

--- a/src/LaunchDarkly.Client/LaunchDarkly.Client.csproj
+++ b/src/LaunchDarkly.Client/LaunchDarkly.Client.csproj
@@ -15,16 +15,15 @@
     <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.Common" Version="1.0.1" />
+    <PackageReference Include="LaunchDarkly.Common.StrongName" Version="1.0.3" />
     <PackageReference Include="Common.Logging" Version="3.4.1" />
     <PackageReference Include="Newtonsoft.Json" Version="9.0.1" Condition="'$(TargetFramework)' != 'net45'" />
     <PackageReference Include="Newtonsoft.Json" Version="6.0.1" Condition="'$(TargetFramework)' == 'net45'" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
     <Reference Include="System" />
+    <Reference Include="System.Net.Http" />
     <Reference Include="Microsoft.CSharp" />
-    <PackageReference Include="System.Runtime" Version="4.3.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.2" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/src/LaunchDarkly.Client/LaunchDarkly.Client.csproj
+++ b/src/LaunchDarkly.Client/LaunchDarkly.Client.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>5.1.1</Version>
+    <Version>5.2.0</Version>
     <TargetFrameworks>netstandard1.4;netstandard1.6;netstandard2.0;net45</TargetFrameworks>
     <PackageLicenseUrl>https://raw.githubusercontent.com/launchdarkly/.net-client/master/LICENSE</PackageLicenseUrl>
     <DebugType>portable</DebugType>

--- a/src/LaunchDarkly.Client/LdClient.cs
+++ b/src/LaunchDarkly.Client/LdClient.cs
@@ -162,8 +162,15 @@ namespace LaunchDarkly.Client
             }
             if (!Initialized())
             {
-                Log.Warn("AllFlags() was called before client has finished initializing. Returning null.");
-                return null;
+                if (_featureStore.Initialized())
+                {
+                    Log.Warn("AllFlags() called before client initialized; using last known values from feature store");
+                }
+                else
+                {
+                    Log.Warn("AllFlags() called before client initialized; feature store unavailable, returning null");
+                    return null;
+                }
             }
             if (user == null || user.Key == null)
             {
@@ -192,8 +199,15 @@ namespace LaunchDarkly.Client
         {
             if (!Initialized())
             {
-                Log.Warn("LaunchDarkly client has not yet been initialized. Returning default");
-                return defaultValue;
+                if (_featureStore.Initialized())
+                {
+                    Log.Warn("Flag evaluation before client initialized; using last known values from feature store");
+                }
+                else
+                {
+                    Log.Warn("Flag evaluation before client initialized; feature store unavailable, returning default value");
+                    return defaultValue;
+                }
             }
             
             try

--- a/src/LaunchDarkly.Client/LdClient.cs
+++ b/src/LaunchDarkly.Client/LdClient.cs
@@ -82,7 +82,16 @@ namespace LaunchDarkly.Client
                     _configuration.StartWaitTime.TotalMilliseconds);
             }
 
-            var unused = initTask.Wait(_configuration.StartWaitTime);
+            try
+            {
+                var unused = initTask.Wait(_configuration.StartWaitTime);
+            }
+            catch (AggregateException)
+            {
+                // StreamProcessor may throw an exception if initialization fails, because we want that behavior
+                // in the Xamarin client. However, for backward compatibility we do not want to throw exceptions
+                // from the LdClient constructor in the .NET client, so we'll just swallow this.
+            }
         }
 
         /// <summary>

--- a/src/LaunchDarkly.Client/LdClient.cs
+++ b/src/LaunchDarkly.Client/LdClient.cs
@@ -17,9 +17,9 @@ namespace LaunchDarkly.Client
         private static readonly ILog Log = LogManager.GetLogger(typeof(LdClient));
 
         private readonly Configuration _configuration;
-        private readonly IEventProcessor _eventProcessor;
+        internal readonly IEventProcessor _eventProcessor;
         private readonly IFeatureStore _featureStore;
-        private readonly IUpdateProcessor _updateProcessor;
+        internal readonly IUpdateProcessor _updateProcessor;
         private readonly EventFactory _eventFactory = EventFactory.Default;
         private bool _shouldDisposeEventProcessor;
         private bool _shouldDisposeFeatureStore;

--- a/src/LaunchDarkly.Client/Operator.cs
+++ b/src/LaunchDarkly.Client/Operator.cs
@@ -27,9 +27,9 @@ namespace LaunchDarkly.Client
                             return true;
                         }
 
-                        if (uValue.Type.Equals(JTokenType.String) && cValue.Type.Equals(JTokenType.String))
+                        if (uValue.Type.Equals(JTokenType.String) || cValue.Type.Equals(JTokenType.String))
                         {
-                            return uValue.Value<string>().Equals(cValue.Value<string>());
+                            return StringOperator(uValue, cValue, (a, b) => a.Equals(b));
                         }
 
                         if (TryCompareNumericValues(uValue, cValue, out comparison))

--- a/src/LaunchDarkly.Client/Operator.cs
+++ b/src/LaunchDarkly.Client/Operator.cs
@@ -117,7 +117,12 @@ namespace LaunchDarkly.Client
         {
             if (uValue.Type.Equals(JTokenType.String) && cValue.Type.Equals(JTokenType.String))
             {
-                return fn(uValue.Value<string>(), cValue.Value<string>());
+                string us = uValue.Value<string>();
+                string cs = cValue.Value<string>();
+                if (us != null && cs != null)
+                {
+                    return fn(us, cs);
+                }
             }
             return false;
         }
@@ -153,7 +158,12 @@ namespace LaunchDarkly.Client
                 case JTokenType.Date:
                     return jValue.Value<DateTime>().ToUniversalTime();
                 case JTokenType.String:
-                    return DateTime.Parse(jValue.Value<string>()).ToUniversalTime();
+                    string s = jValue.Value<string>();
+                    if (s == null)
+                    {
+                        return null;
+                    }
+                    return DateTime.Parse(s).ToUniversalTime();
                 default:
                     var jvalueDouble = ParseDoubleFromJValue(jValue);
                     if (jvalueDouble.HasValue)
@@ -167,11 +177,11 @@ namespace LaunchDarkly.Client
 
         internal static SemanticVersion JValueToSemVer(JValue jValue)
         {
-            if (jValue.Type == JTokenType.String)
+            if (jValue.Type == JTokenType.String && jValue.Value<string>() != null)
             {
                 try
                 {
-                    return SemanticVersion.Parse(jValue.Value<String>(), allowMissingMinorAndPatch: true);
+                    return SemanticVersion.Parse(jValue.Value<string>(), allowMissingMinorAndPatch: true);
                 }
                 catch (ArgumentException)
                 {

--- a/test/LaunchDarkly.Tests/FeatureFlagBuilder.cs
+++ b/test/LaunchDarkly.Tests/FeatureFlagBuilder.cs
@@ -122,5 +122,13 @@ namespace LaunchDarkly.Tests
             _deleted = deleted;
             return this;
         }
+
+        internal FeatureFlagBuilder OffWithValue(JToken value)
+        {
+            _on = false;
+            _offVariation = 0;
+            _variations = new List<JToken> { value };
+            return this;
+        }
     }
 }

--- a/test/LaunchDarkly.Tests/FeatureFlagBuilder.cs
+++ b/test/LaunchDarkly.Tests/FeatureFlagBuilder.cs
@@ -130,5 +130,14 @@ namespace LaunchDarkly.Tests
             _variations = new List<JToken> { value };
             return this;
         }
+
+        internal FeatureFlagBuilder BooleanWithClauses(params Clause[] clauses)
+        {
+            _on = true;
+            _offVariation = 0;
+            _variations = new List<JToken> { new JValue(false), new JValue(true) };
+            _rules = new List<Rule> { new Rule(1, null, new List<Clause>(clauses)) };
+            return this;
+        }
     }
 }

--- a/test/LaunchDarkly.Tests/LaunchDarkly.Tests.csproj
+++ b/test/LaunchDarkly.Tests/LaunchDarkly.Tests.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="LaunchDarkly.Common" Version="1.0.1" />
+    <PackageReference Include="LaunchDarkly.Common.StrongName" Version="1.0.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
     <PackageReference Include="Moq" Version="4.8.1" />
     <PackageReference Include="WireMock.Net" Version="1.0.3.8" />

--- a/test/LaunchDarkly.Tests/LdClientEvaluationTest.cs
+++ b/test/LaunchDarkly.Tests/LdClientEvaluationTest.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using LaunchDarkly.Client;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace LaunchDarkly.Tests
+{
+    public class LdClientEvaluationTest
+    {
+        private static readonly User user = User.WithKey("userkey");
+        private IFeatureStore featureStore = new InMemoryFeatureStore();
+        private ILdClient client;
+
+        public LdClientEvaluationTest()
+        {
+            var config = Configuration.Default("SDK_KEY")
+                .WithFeatureStoreFactory(new SpecificFeatureStoreFactory(featureStore))
+                .WithEventProcessorFactory(Components.NullEventProcessor)
+                .WithUpdateProcessorFactory(Components.NullUpdateProcessor);
+            client = new LdClient(config);
+        }
+
+        [Fact]
+        public void BoolVariationReturnsFlagValue()
+        {
+            featureStore.Upsert(VersionedDataKind.Features,
+                new FeatureFlagBuilder("key").OffWithValue(new JValue(true)).Build());
+
+            Assert.True(client.BoolVariation("key", user, false));
+        }
+
+        [Fact]
+        public void BoolVariationReturnsDefaultValueForUnknownFlag()
+        {
+            Assert.False(client.BoolVariation("key", user, false));
+        }
+
+        [Fact]
+        public void IntVariationReturnsFlagValue()
+        {
+            featureStore.Upsert(VersionedDataKind.Features,
+                new FeatureFlagBuilder("key").OffWithValue(new JValue(2)).Build());
+
+            Assert.Equal(2, client.IntVariation("key", user, 1));
+        }
+
+        [Fact]
+        public void IntVariationReturnsDefaultValueForUnknownFlag()
+        {
+            Assert.Equal(1, client.IntVariation("key", user, 1));
+        }
+
+        [Fact]
+        public void FloatVariationReturnsFlagValue()
+        {
+            featureStore.Upsert(VersionedDataKind.Features,
+                new FeatureFlagBuilder("key").OffWithValue(new JValue(2.5f)).Build());
+
+            Assert.Equal(2.5f, client.FloatVariation("key", user, 1.0f));
+        }
+
+        [Fact]
+        public void FloatVariationReturnsDefaultValueForUnknownFlag()
+        {
+            Assert.Equal(1.0f, client.FloatVariation("key", user, 1.0f));
+        }
+
+        [Fact]
+        public void StringVariationReturnsFlagValue()
+        {
+            featureStore.Upsert(VersionedDataKind.Features,
+                new FeatureFlagBuilder("key").OffWithValue(new JValue("b")).Build());
+
+            Assert.Equal("b", client.StringVariation("key", user, "a"));
+        }
+
+        [Fact]
+        public void StringVariationReturnsDefaultValueForUnknownFlag()
+        {
+            Assert.Equal("a", client.StringVariation("key", user, "a"));
+        }
+
+        [Fact]
+        public void JsonVariationReturnsFlagValue()
+        {
+            var data = new JObject();
+            data.Add("thing", new JValue("stuff"));
+            featureStore.Upsert(VersionedDataKind.Features,
+                new FeatureFlagBuilder("key").OffWithValue(data).Build());
+
+            Assert.Equal(data, client.JsonVariation("key", user, new JValue(42)));
+        }
+
+        [Fact]
+        public void JsonVariationReturnsDefaultValueForUnknownFlag()
+        {
+            var defaultVal = new JValue(42);
+            Assert.Equal(defaultVal, client.JsonVariation("key", user, defaultVal));
+        }
+        
+        [Fact]
+        public void CanMatchUserBySegment()
+        {
+            var segment = new Segment("segment1", 1, new List<string> { user.Key }, null, "", null, false);
+            featureStore.Upsert(VersionedDataKind.Segments, segment);
+
+            var clause = new Clause("", "segmentMatch", new List<JValue> { new JValue("segment1") }, false);
+            var feature = new FeatureFlagBuilder("feature").BooleanWithClauses(clause).Build();
+            featureStore.Upsert(VersionedDataKind.Features, feature);
+
+            Assert.True(client.BoolVariation("feature", user, false));
+        }
+    }
+}

--- a/test/LaunchDarkly.Tests/LdClientEventTest.cs
+++ b/test/LaunchDarkly.Tests/LdClientEventTest.cs
@@ -1,0 +1,240 @@
+﻿using System.Collections.Generic;
+using LaunchDarkly.Client;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace LaunchDarkly.Tests
+{
+    public class LdClientEventTest
+    {
+        private static readonly User user = User.WithKey("userkey");
+        private IFeatureStore featureStore = new InMemoryFeatureStore();
+        private TestEventProcessor eventSink = new TestEventProcessor();
+        private ILdClient client;
+
+        public LdClientEventTest()
+        {
+            var config = Configuration.Default("SDK_KEY")
+                .WithFeatureStoreFactory(TestUtils.SpecificFeatureStore(featureStore))
+                .WithEventProcessorFactory(TestUtils.SpecificEventProcessor(eventSink))
+                .WithUpdateProcessorFactory(Components.NullUpdateProcessor);
+            client = new LdClient(config);
+        }
+
+        [Fact]
+        public void IdentifySendsEvent()
+        {
+            client.Identify(user);
+
+            Assert.Equal(1, eventSink.Events.Count);
+            var ie = Assert.IsType<IdentifyEvent>(eventSink.Events[0]);
+            Assert.Equal(user.Key, ie.User.Key);
+        }
+
+        [Fact]
+        public void TrackSendsEventWithoutData()
+        {
+            client.Track("eventkey", user);
+
+            Assert.Equal(1, eventSink.Events.Count);
+            var ce = Assert.IsType<CustomEvent>(eventSink.Events[0]);
+            Assert.Equal(user.Key, ce.User.Key);
+            Assert.Equal("eventkey", ce.Key);
+            Assert.Null(ce.JsonData);
+        }
+
+        [Fact]
+        public void TrackSendsEventWithData()
+        {
+            var data = new JObject();
+            data.Add("thing", new JValue("stuff"));
+            client.Track("eventkey", data, user);
+
+            Assert.Equal(1, eventSink.Events.Count);
+            var ce = Assert.IsType<CustomEvent>(eventSink.Events[0]);
+            Assert.Equal(user.Key, ce.User.Key);
+            Assert.Equal("eventkey", ce.Key);
+            Assert.Equal(data, ce.JsonData);
+        }
+
+        [Fact]
+        public void TrackSendsEventWithStringData()
+        {
+            client.Track("eventkey", user, "thing");
+
+            Assert.Equal(1, eventSink.Events.Count);
+            var ce = Assert.IsType<CustomEvent>(eventSink.Events[0]);
+            Assert.Equal(user.Key, ce.User.Key);
+            Assert.Equal("eventkey", ce.Key);
+            Assert.Equal(new JValue("thing"), ce.JsonData);
+        }
+
+        [Fact]
+        public void BoolVariationSendsEvent()
+        {
+            var flag = new FeatureFlagBuilder("key").OffWithValue(new JValue(true)).Build();
+            featureStore.Upsert(VersionedDataKind.Features, flag);
+
+            client.BoolVariation("key", user, false);
+            Assert.Equal(1, eventSink.Events.Count);
+            CheckFeatureEvent(eventSink.Events[0], flag, new JValue(true), new JValue(false), null);
+        }
+
+        [Fact]
+        public void BoolVariationSendsEventForUnknownFlag()
+        {
+            client.BoolVariation("key", user, false);
+            Assert.Equal(1, eventSink.Events.Count);
+            CheckUnknownFeatureEvent(eventSink.Events[0], "key", new JValue(false), null);
+        }
+
+        [Fact]
+        public void IntVariationSendsEvent()
+        {
+            var flag = new FeatureFlagBuilder("key").OffWithValue(new JValue(2)).Build();
+            featureStore.Upsert(VersionedDataKind.Features, flag);
+
+            client.IntVariation("key", user, 1);
+            Assert.Equal(1, eventSink.Events.Count);
+            CheckFeatureEvent(eventSink.Events[0], flag, new JValue(2), new JValue(1), null);
+        }
+
+        [Fact]
+        public void IntVariationSendsEventForUnknownFlag()
+        {
+            client.IntVariation("key", user, 1);
+            Assert.Equal(1, eventSink.Events.Count);
+            CheckUnknownFeatureEvent(eventSink.Events[0], "key", new JValue(1), null);
+        }
+
+        [Fact]
+        public void FloatVariationSendsEvent()
+        {
+            var flag = new FeatureFlagBuilder("key").OffWithValue(new JValue(2.5f)).Build();
+            featureStore.Upsert(VersionedDataKind.Features, flag);
+
+            client.FloatVariation("key", user, 1.0f);
+            Assert.Equal(1, eventSink.Events.Count);
+            CheckFeatureEvent(eventSink.Events[0], flag, new JValue(2.5f), new JValue(1.0f), null);
+        }
+
+        [Fact]
+        public void FloatVariationSendsEventForUnknownFlag()
+        {
+            client.FloatVariation("key", user, 1.0f);
+            Assert.Equal(1, eventSink.Events.Count);
+            CheckUnknownFeatureEvent(eventSink.Events[0], "key", new JValue(1.0f), null);
+        }
+
+        [Fact]
+        public void StringVariationSendsEvent()
+        {
+            var flag = new FeatureFlagBuilder("key").OffWithValue(new JValue("b")).Build();
+            featureStore.Upsert(VersionedDataKind.Features, flag);
+
+            client.StringVariation("key", user, "a");
+            Assert.Equal(1, eventSink.Events.Count);
+            CheckFeatureEvent(eventSink.Events[0], flag, new JValue("b"), new JValue("a"), null);
+        }
+
+        [Fact]
+        public void StringVariationSendsEventForUnknownFlag()
+        {
+            client.StringVariation("key", user, "a");
+            Assert.Equal(1, eventSink.Events.Count);
+            CheckUnknownFeatureEvent(eventSink.Events[0], "key", new JValue("a"), null);
+        }
+
+        [Fact]
+        public void JsonVariationSendsEvent()
+        {
+            var data = new JObject();
+            data.Add("thing", new JValue("stuff"));
+            var flag = new FeatureFlagBuilder("key").OffWithValue(data).Build();
+            featureStore.Upsert(VersionedDataKind.Features, flag);
+            var defaultVal = new JValue(42);
+
+            client.JsonVariation("key", user, defaultVal);
+            Assert.Equal(1, eventSink.Events.Count);
+            CheckFeatureEvent(eventSink.Events[0], flag, data, defaultVal, null);
+        }
+
+        [Fact]
+        public void JsonVariationSendsEventForUnknownFlag()
+        {
+            var defaultVal = new JValue(42);
+
+            client.JsonVariation("key", user, defaultVal);
+            Assert.Equal(1, eventSink.Events.Count);
+            CheckUnknownFeatureEvent(eventSink.Events[0], "key", defaultVal, null);
+        }
+
+        [Fact]
+        public void EventIsSentForExistingPrerequisiteFlag()
+        {
+            var f0 = new FeatureFlagBuilder("feature0")
+                .On(true)
+                .Prerequisites(new List<Prerequisite> { new Prerequisite("feature1", 1) })
+                .Fallthrough(new VariationOrRollout(0, null))
+                .OffVariation(1)
+                .Variations(new List<JToken> { new JValue("fall"), new JValue("off"), new JValue("on") })
+                .Version(1)
+                .Build();
+            var f1 = new FeatureFlagBuilder("feature1")
+                .On(true)
+                .Fallthrough(new VariationOrRollout(1, null))
+                .Variations(new List<JToken> { new JValue("nogo"), new JValue("go") })
+                .Version(2)
+                .Build();
+            featureStore.Upsert(VersionedDataKind.Features, f0);
+            featureStore.Upsert(VersionedDataKind.Features, f1);
+
+            client.StringVariation("feature0", user, "default");
+
+            Assert.Equal(2, eventSink.Events.Count);
+            CheckFeatureEvent(eventSink.Events[0], f1, new JValue("go"), null, "feature0");
+            CheckFeatureEvent(eventSink.Events[1], f0, new JValue("fall"), new JValue("default"), null);
+        }
+        
+        [Fact]
+        public void EventIsNotSentForUnknownPrerequisiteFlag()
+        {
+            var f0 = new FeatureFlagBuilder("feature0")
+                .On(true)
+                .Prerequisites(new List<Prerequisite> { new Prerequisite("feature1", 1) })
+                .Fallthrough(new VariationOrRollout(0, null))
+                .OffVariation(1)
+                .Variations(new List<JToken> { new JValue("fall"), new JValue("off"), new JValue("on") })
+                .Version(1)
+                .Build();
+            featureStore.Upsert(VersionedDataKind.Features, f0);
+
+            client.StringVariation("feature0", user, "default");
+
+            Assert.Equal(1, eventSink.Events.Count);
+            CheckFeatureEvent(eventSink.Events[0], f0, new JValue("off"), new JValue("default"), null);
+        }
+
+        private void CheckFeatureEvent(Event e, FeatureFlag flag, JToken value, JToken defaultVal, string prereqOf)
+        {
+            var fe = Assert.IsType<FeatureRequestEvent>(e);
+            Assert.Equal(flag.Key, fe.Key);
+            Assert.Equal(user.Key, fe.User.Key);
+            Assert.Equal(flag.Version, fe.Version);
+            Assert.Equal(value, fe.Value);
+            Assert.Equal(defaultVal, fe.Default);
+            Assert.Equal(prereqOf, fe.PrereqOf);
+        }
+
+        private void CheckUnknownFeatureEvent(Event e, string key, JToken defaultVal, string prereqOf)
+        {
+            var fe = Assert.IsType<FeatureRequestEvent>(e);
+            Assert.Equal(key, fe.Key);
+            Assert.Equal(user.Key, fe.User.Key);
+            Assert.Null(fe.Version);
+            Assert.Equal(defaultVal, fe.Value);
+            Assert.Equal(defaultVal, fe.Default);
+            Assert.Equal(prereqOf, fe.PrereqOf);
+        }
+    }
+}

--- a/test/LaunchDarkly.Tests/LdClientLddModeTest.cs
+++ b/test/LaunchDarkly.Tests/LdClientLddModeTest.cs
@@ -1,0 +1,58 @@
+﻿using LaunchDarkly.Client;
+using LaunchDarkly.Common;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace LaunchDarkly.Tests
+{
+    public class LdClientLddModeTest
+    {
+        [Fact]
+        public void LddModeClientHasNullUpdateProcessor()
+        {
+            Configuration config = Configuration.Default("SDK_KEY")
+                .WithUseLdd(true);
+            using (var client = new LdClient(config))
+            {
+                Assert.IsType<NullUpdateProcessor>(client._updateProcessor);
+            }
+        }
+
+        [Fact]
+        public void LddModeClientHasDefaultEventProcessor()
+        {
+            Configuration config = Configuration.Default("SDK_KEY")
+                .WithUseLdd(true);
+            using (var client = new LdClient(config))
+            {
+                Assert.IsType<DefaultEventProcessor>(client._eventProcessor);
+            }
+        }
+
+        [Fact]
+        public void LddModeClientIsInitialized()
+        {
+            Configuration config = Configuration.Default("SDK_KEY")
+                .WithUseLdd(true);
+            using (var client = new LdClient(config))
+            {
+                Assert.True(client.Initialized());
+            }
+        }
+
+        [Fact]
+        public void LddModeClientGetsFlagFromFeatureStore()
+        {
+            IFeatureStore featureStore = new InMemoryFeatureStore();
+            featureStore.Upsert(VersionedDataKind.Features,
+                new FeatureFlagBuilder("key").OffWithValue(new JValue(true)).Build());
+            Configuration config = Configuration.Default("SDK_KEY")
+                .WithUseLdd(true)
+                .WithFeatureStoreFactory(TestUtils.SpecificFeatureStore(featureStore));
+            using (var client = new LdClient(config))
+            {
+                Assert.True(client.BoolVariation("key", User.WithKey("user"), false));
+            }
+        }
+    }
+}

--- a/test/LaunchDarkly.Tests/LdClientLddModeTest.cs
+++ b/test/LaunchDarkly.Tests/LdClientLddModeTest.cs
@@ -10,7 +10,7 @@ namespace LaunchDarkly.Tests
         [Fact]
         public void LddModeClientHasNullUpdateProcessor()
         {
-            Configuration config = Configuration.Default("SDK_KEY")
+            var config = Configuration.Default("SDK_KEY")
                 .WithUseLdd(true);
             using (var client = new LdClient(config))
             {
@@ -21,7 +21,7 @@ namespace LaunchDarkly.Tests
         [Fact]
         public void LddModeClientHasDefaultEventProcessor()
         {
-            Configuration config = Configuration.Default("SDK_KEY")
+            var config = Configuration.Default("SDK_KEY")
                 .WithUseLdd(true);
             using (var client = new LdClient(config))
             {
@@ -32,7 +32,7 @@ namespace LaunchDarkly.Tests
         [Fact]
         public void LddModeClientIsInitialized()
         {
-            Configuration config = Configuration.Default("SDK_KEY")
+            var config = Configuration.Default("SDK_KEY")
                 .WithUseLdd(true);
             using (var client = new LdClient(config))
             {
@@ -43,10 +43,10 @@ namespace LaunchDarkly.Tests
         [Fact]
         public void LddModeClientGetsFlagFromFeatureStore()
         {
-            IFeatureStore featureStore = new InMemoryFeatureStore();
+            var featureStore = new InMemoryFeatureStore();
             featureStore.Upsert(VersionedDataKind.Features,
                 new FeatureFlagBuilder("key").OffWithValue(new JValue(true)).Build());
-            Configuration config = Configuration.Default("SDK_KEY")
+            var config = Configuration.Default("SDK_KEY")
                 .WithUseLdd(true)
                 .WithFeatureStoreFactory(TestUtils.SpecificFeatureStore(featureStore));
             using (var client = new LdClient(config))

--- a/test/LaunchDarkly.Tests/LdClientOfflineTest.cs
+++ b/test/LaunchDarkly.Tests/LdClientOfflineTest.cs
@@ -1,0 +1,81 @@
+﻿using System.Collections.Generic;
+using LaunchDarkly.Client;
+using Newtonsoft.Json.Linq;
+using Xunit;
+
+namespace LaunchDarkly.Tests
+{
+    public class LdClientOfflineTest
+    {
+        [Fact]
+        public void OfflineClientHasNullUpdateProcessor()
+        {
+            var config = Configuration.Default("SDK_KEY")
+                .WithOffline(true);
+            using (var client = new LdClient(config))
+            {
+                Assert.IsType<NullUpdateProcessor>(client._updateProcessor);
+            }
+        }
+
+        [Fact]
+        public void LddModeClientHasNullEventProcessor()
+        {
+            var config = Configuration.Default("SDK_KEY")
+                .WithOffline(true);
+            using (var client = new LdClient(config))
+            {
+                Assert.IsType<NullEventProcessor>(client._eventProcessor);
+            }
+        }
+
+        [Fact]
+        public void OfflineClientIsInitialized()
+        {
+            var config = Configuration.Default("SDK_KEY")
+                .WithOffline(true);
+            using (var client = new LdClient(config))
+            {
+                Assert.True(client.Initialized());
+            }
+        }
+
+        [Fact]
+        public void OfflineReturnsDefaultValue()
+        {
+            var config = Configuration.Default("SDK_KEY")
+                .WithOffline(true);
+            using (var client = new LdClient(config))
+            {
+                Assert.Equal("x", client.StringVariation("key", User.WithKey("user"), "x"));
+            }
+        }
+
+        [Fact]
+        public void OfflineClientGetsFlagFromFeatureStore()
+        {
+            var featureStore = new InMemoryFeatureStore();
+            featureStore.Upsert(VersionedDataKind.Features,
+                new FeatureFlagBuilder("key").OffWithValue(new JValue(true)).Build());
+            var config = Configuration.Default("SDK_KEY")
+                .WithOffline(true)
+                .WithFeatureStoreFactory(TestUtils.SpecificFeatureStore(featureStore));
+            using (var client = new LdClient(config))
+            {
+                Assert.Equal(true, client.BoolVariation("key", User.WithKey("user"), false));
+            }
+        }
+
+        [Fact]
+        public void TestSecureModeHash()
+        {
+            var config = Configuration.Default("secret")
+                .WithOffline(true);
+            using (var client = new LdClient(config))
+            {
+                Assert.Equal("aa747c502a898200f9e4fa21bac68136f886a0e27aec70ba06daf2e2a5cb5597",
+                    client.SecureModeHash(User.WithKey("Message")));
+            }
+        }
+    }
+}

--- a/test/LaunchDarkly.Tests/LdClientTest.cs
+++ b/test/LaunchDarkly.Tests/LdClientTest.cs
@@ -91,11 +91,26 @@ namespace LaunchDarkly.Tests
         }
 
         [Fact]
-        public void EvaluationReturnsDefaultValueIfClientIsNotInited()
+        public void EvaluationReturnsDefaultValueIfNeitherClientNorFeatureStoreIsInited()
         {
-            // Note, this tests the current behavior of the .NET client, but it is inconsistent with the other
-            // SDKs: for consistency, it should use the feature store if the feature store is initialized.
+            var featureStore = new InMemoryFeatureStore();
+            var flag = new FeatureFlagBuilder("key").OffWithValue(new JValue(1)).Build();
+            featureStore.Upsert(VersionedDataKind.Features, flag); // but the store is still not inited
 
+            var config = Configuration.Default("SDK_KEY").WithStartWaitTime(TimeSpan.Zero)
+                .WithFeatureStoreFactory(TestUtils.SpecificFeatureStore(featureStore))
+                .WithUpdateProcessorFactory(TestUtils.SpecificUpdateProcessor(updateProcessor))
+                .WithEventProcessorFactory(Components.NullEventProcessor);
+
+            using (var client = new LdClient(config))
+            {
+                Assert.Equal(0, client.IntVariation("key", User.WithKey("user"), 0));
+            }
+        }
+
+        [Fact]
+        public void EvaluationUsesFeatureStoreIfClientIsNotInitedButStoreIsInited()
+        {
             var featureStore = new InMemoryFeatureStore();
             featureStore.Init(new Dictionary<IVersionedDataKind, IDictionary<string, IVersionedData>>());
             var flag = new FeatureFlagBuilder("key").OffWithValue(new JValue(1)).Build();
@@ -108,7 +123,46 @@ namespace LaunchDarkly.Tests
 
             using (var client = new LdClient(config))
             {
-                Assert.Equal(0, client.IntVariation("key", User.WithKey("user"), 0));
+                Assert.Equal(1, client.IntVariation("key", User.WithKey("user"), 0));
+            }
+        }
+
+        [Fact]
+        public void AllFlagsReturnsNullIfNeitherClientNorFeatureStoreIsInited()
+        {
+            var featureStore = new InMemoryFeatureStore();
+            var flag = new FeatureFlagBuilder("key").OffWithValue(new JValue(1)).Build();
+            featureStore.Upsert(VersionedDataKind.Features, flag); // but the store is still not inited
+
+            var config = Configuration.Default("SDK_KEY").WithStartWaitTime(TimeSpan.Zero)
+                .WithFeatureStoreFactory(TestUtils.SpecificFeatureStore(featureStore))
+                .WithUpdateProcessorFactory(TestUtils.SpecificUpdateProcessor(updateProcessor))
+                .WithEventProcessorFactory(Components.NullEventProcessor);
+
+            using (var client = new LdClient(config))
+            {
+                Assert.Null(client.AllFlags(User.WithKey("user")));
+            }
+        }
+        
+        [Fact]
+        public void AllFlagsUsesFeatureStoreIfClientIsNotInitedButStoreIsInited()
+        {
+            var featureStore = new InMemoryFeatureStore();
+            featureStore.Init(new Dictionary<IVersionedDataKind, IDictionary<string, IVersionedData>>());
+            var flag = new FeatureFlagBuilder("key").OffWithValue(new JValue(1)).Build();
+            featureStore.Upsert(VersionedDataKind.Features, flag);
+
+            var config = Configuration.Default("SDK_KEY").WithStartWaitTime(TimeSpan.Zero)
+                .WithFeatureStoreFactory(TestUtils.SpecificFeatureStore(featureStore))
+                .WithUpdateProcessorFactory(TestUtils.SpecificUpdateProcessor(updateProcessor))
+                .WithEventProcessorFactory(Components.NullEventProcessor);
+
+            using (var client = new LdClient(config))
+            {
+                IDictionary<string, JToken> result = client.AllFlags(User.WithKey("user"));
+                Assert.NotNull(result);
+                Assert.Equal(new JValue(1), result["key"]);
             }
         }
     }

--- a/test/LaunchDarkly.Tests/TestUtils.cs
+++ b/test/LaunchDarkly.Tests/TestUtils.cs
@@ -1,4 +1,5 @@
-﻿using LaunchDarkly.Client;
+﻿using System.Collections.Generic;
+using LaunchDarkly.Client;
 
 namespace LaunchDarkly.Tests
 {
@@ -12,6 +13,11 @@ namespace LaunchDarkly.Tests
         public static IEventProcessorFactory SpecificEventProcessor(IEventProcessor ep)
         {
             return new SpecificEventProcessorFactory(ep);
+        }
+
+        public static IUpdateProcessorFactory SpecificUpdateProcessor(IUpdateProcessor up)
+        {
+            return new SpecificUpdateProcessorFactory(up);
         }
     }
 
@@ -43,5 +49,34 @@ namespace LaunchDarkly.Tests
         {
             return _ep;
         }
+    }
+
+    public class SpecificUpdateProcessorFactory : IUpdateProcessorFactory
+    {
+        private readonly IUpdateProcessor _up;
+
+        public SpecificUpdateProcessorFactory(IUpdateProcessor up)
+        {
+            _up = up;
+        }
+
+        IUpdateProcessor IUpdateProcessorFactory.CreateUpdateProcessor(Configuration config, IFeatureStore featureStore)
+        {
+            return _up;
+        }
+    }
+
+    public class TestEventProcessor : IEventProcessor
+    {
+        public List<Event> Events = new List<Event>();
+
+        public void SendEvent(Event e)
+        {
+            Events.Add(e);
+        }
+
+        public void Flush() { }
+
+        public void Dispose() { }
     }
 }


### PR DESCRIPTION
## [5.2.0] - 2018-07-27
### Added:
- New configuration property `UseLdd` allows the client to use the "LaunchDarkly Daemon", i.e. getting feature flag data from a store that is updated by an [`ld-relay`](https://docs.launchdarkly.com/docs/the-relay-proxy) instance. However, this will not be usable until the Redis feature store integration is released (soon).

### Changed:
- If you attempt to evaluate a flag before the client has established a connection, but you are using a feature store that has already been populated, the client will now use the last known values from the store instead of returning default values.
- The `LaunchDarkly.Common` package, which is used by `LaunchDarkly.Client`, has been renamed to `LaunchDarkly.Common.StrongName`. Note that you should not have to explicitly install this package; it will be imported automatically.

### Fixed:
- The SDK was referencing several system assemblies via `<PackageReference>`, which could cause dependency conflicts. These have been changed to framework `<Reference>`s. A redundant reference to `System.Runtime` was removed. ([#83](https://github.com/launchdarkly/dotnet-client/issues/83))
- The client was logging (at debug level) a lengthy exception stacktrace whenever a string comparison operator was applied to a user property that was null. It no longer does this.