### PR TITLE
Correct summary for StartWaitTime 

### DIFF
--- a/src/LaunchDarkly.Client/Configuration.cs
+++ b/src/LaunchDarkly.Client/Configuration.cs
@@ -57,7 +57,7 @@ namespace LaunchDarkly.Client
         /// <summary>
         /// How long the client constructor will block awaiting a successful connection to
         /// LaunchDarkly. Setting this to 0 will not block and will cause the constructor to return
-        /// immediately. The default value is 5 seconds.
+        /// immediately. The default value is 10 seconds.
         /// </summary>
         public TimeSpan StartWaitTime { get; internal set; }
         /// <summary>


### PR DESCRIPTION
Corrected summary from 5 seconds to 10 seconds. https://github.com/launchdarkly/dotnet-client/blob/master/src/LaunchDarkly.Client/Configuration.cs#L170